### PR TITLE
Add offset param

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ tumblrLksDownldr.setGlobalParams(
   {
     url: 'yourblog.tumblr.com',
     postsToLoad: '10',
+    postsOffset: '10',
     path: 'some-path-you-want',
     onStart: (info) => {
       console.log('onStart:', info);

--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,7 @@ const pizzaGuy = require('pizza-guy');
 const API_KEY = 'pXcUXQdlBndW7znq4C4vodeQg0OxCXOlXv2RamTphjNFj0MuzI';
 const imagesToDownload = [];
 let postsToLoad;
+let postsOffset = 0;
 let tumblrBlogUrl = '';
 let downloadedPosts = 0;
 let customPathToSave = '';
@@ -30,6 +31,9 @@ const setGlobalParams = (params) => {
   postsToLoad = typeof params.postsToLoad !== 'undefined'
     ? Number(params.postsToLoad)
     : postsToLoad;
+  postsOffset = typeof params.postsOffset !== 'undefined'
+      ? Number(params.postsOffset)
+      : postsOffset;
   customPathToSave = params.path
     ? params.path[0] === '/'
       ? `${params.path}`
@@ -63,11 +67,15 @@ const downloadImages = () => {
 const getLikedPosts = (timestamp) => {
 
   const beforeParam = timestamp ? `&before=${timestamp}` : '';
+  if (timestamp) {
+    postsOffset = 0;
+  }
+  const offsetParam = postsOffset > 0 ? `&offset=${postsOffset}` : '';
   http.get(
     {
       host: 'api.tumblr.com',
       port: 80,
-      path: `/v2/blog/${tumblrBlogUrl}/likes?api_key=${API_KEY}${beforeParam}`
+      path: `/v2/blog/${tumblrBlogUrl}/likes?api_key=${API_KEY}${beforeParam}${offsetParam}`
     },
     (response) => {
       let data = '';


### PR DESCRIPTION
"postsOffset" param allows you to start the download at a number of posts away from the first (the offset param in the Tumblr api). This is helpful if you have a ton of posts to download and want to do them in batch (i.e. 100, offset at 0; 100 offset at 100; 100 offset at 200).

It only uses the offset param the first time the likes are retrieved, then it is removed for the subsequent requests that use the timestamp.

Run it a few times on my blog and it seems to be working.

see also https://github.com/andresdavid90/tumblr-lks-downldr-cli/pull/6
